### PR TITLE
fix: 文件系统上传改传 path 替代 parentId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-file-manager",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "用于管理文件.",
   "scripts": {
     "init": "husky",

--- a/src/components/FileSystem/FileSystem.js
+++ b/src/components/FileSystem/FileSystem.js
@@ -57,10 +57,10 @@ const createDefaultFolderApis = ({ ajax, apis, type }) => ({
     );
     return resData;
   },
-  uploadFile: async ({ file, parentId }) => {
+  uploadFile: async ({ file, path = '' }) => {
     return ajax.postForm({
       url: apis.fileManager.folderUpload.url,
-      params: { type, parentId: parentId || undefined },
+      params: { type, path },
       data: { file }
     });
   },
@@ -322,7 +322,7 @@ const FileSystemPagedBody = ({
                 try {
                   const response = await folderApis.uploadFile({
                     file,
-                    parentId: resolveParentId()
+                    path: currentPath || ''
                   });
                   if (response?.data?.code != null && response.data.code !== 0) {
                     onError?.(new Error('upload failed'));
@@ -903,7 +903,7 @@ const FileSystem = createWithRemoteLoader({
                           try {
                             const response = await folderApis.uploadFile({
                               file,
-                              parentId: resolveParentId()
+                              path: currentPath || ''
                             });
                             if (response?.data?.code != null && response.data.code !== 0) {
                               onError?.(new Error('upload failed'));

--- a/src/components/FileSystem/README.md
+++ b/src/components/FileSystem/README.md
@@ -393,7 +393,7 @@ render(<BaseExample />);
 | folderTree | GET | `{prefix}/folder/tree`（`kind=folder` 仅文件夹） |
 | folderList | POST | `{prefix}/folder/list`（`parentId` + `currentPage` + `perPage` + 可选 `keyword` → `{ pageData, totalCount }`） |
 | folderMkdir | POST | `{prefix}/folder/mkdir` |
-| folderUpload | POST | `{prefix}/folder/upload` |
+| folderUpload | POST | `{prefix}/folder/upload`（query：`path`，空为根目录） |
 | folderRemove | POST | `{prefix}/folder/remove` |
 | folderMove | POST | `{prefix}/folder/move` |
 | folderCopy | POST | `{prefix}/folder/copy` |

--- a/src/components/FileSystem/doc/api.md
+++ b/src/components/FileSystem/doc/api.md
@@ -33,7 +33,7 @@
 | folderTree | GET | `{prefix}/folder/tree`（`kind=folder` 仅文件夹） |
 | folderList | POST | `{prefix}/folder/list`（`parentId` + `currentPage` + `perPage` + 可选 `keyword` → `{ pageData, totalCount }`） |
 | folderMkdir | POST | `{prefix}/folder/mkdir` |
-| folderUpload | POST | `{prefix}/folder/upload` |
+| folderUpload | POST | `{prefix}/folder/upload`（query：`path`，空为根目录） |
 | folderRemove | POST | `{prefix}/folder/remove` |
 | folderMove | POST | `{prefix}/folder/move` |
 | folderCopy | POST | `{prefix}/folder/copy` |

--- a/src/mockPreset/index.js
+++ b/src/mockPreset/index.js
@@ -711,8 +711,30 @@ const apis = merge(
       folderUpload: {
         loader: ({ params, data } = {}) => {
           const type = params?.type || data?.type || 'default';
-          const parentId = params?.parentId || data?.parentId || null;
+          const folderPath = params?.path !== undefined ? params.path : data?.path;
+          const segments = String(folderPath || '')
+            .replace(/\\/g, '/')
+            .split('/')
+            .map(segment => segment.trim())
+            .filter(segment => segment && segment !== '.' && segment !== '..');
+          let parentId = null;
           const nodes = ensureFolderType(type);
+          for (const name of segments) {
+            let existing = nodes.find(
+              item => (item.parentId || null) === parentId && item.name === name && item.options?.kind === 'folder'
+            );
+            if (!existing) {
+              existing = {
+                id: `folder-${Date.now()}-${folderNodeSeq++}`,
+                type,
+                name,
+                parentId,
+                options: { kind: 'folder' }
+              };
+              nodes.push(existing);
+            }
+            parentId = existing.id;
+          }
           const fileId = `file-${Date.now()}-${folderNodeSeq++}`;
           const filename = data?.file?.name || data?.filename || '新上传文件.pdf';
           const size = data?.file?.size || data?.size || 102400;


### PR DESCRIPTION
避免 parentId 缺失被序列化为 undefined；与后端 folder/upload 的 path 契约对齐。